### PR TITLE
New Feature: Added Rate Limit Management Support in Redis

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,8 @@
+{
+	"semi": true,
+	"trailingComma": "es5",
+	"singleQuote": false,
+	"printWidth": 120,
+	"tabWidth": 2,
+	"useTabs": false
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,10 +1,15 @@
 {
-  "editor.formatOnSave": true,
-  "editor.codeActionsOnSave": {
-    "source.fixAll": true
-  },
-  "editor.defaultFormatter": "esbenp.prettier-vscode",
-  "eslint.enable": true,
-  "eslint.validate": ["javascript", "typescript", "json"],
-  "editor.tabSize": 2
+	"editor.formatOnSave": true,
+	"editor.codeActionsOnSave": {
+		"source.fixAll": "explicit"
+	},
+	"eslint.enable": true,
+	"eslint.validate": ["javascript", "typescript", "json"],
+	"editor.tabSize": 2,
+	"[javascript]": {
+		"editor.defaultFormatter": "esbenp.prettier-vscode"
+	},
+	"[typescript]": {
+		"editor.defaultFormatter": "esbenp.prettier-vscode"
+	}
 }

--- a/README.md
+++ b/README.md
@@ -27,22 +27,29 @@ npm install express-rate-limiter-core
 - Rate-limit per minutes
 - Rate-limit per period
 - Block system to requets
+- Storage in Memory or Redis
+- Support for Storage Customization
 
 ## Cache
 
-- Cache in Memory: Memory cache: it does not have support to scale this is only a simple cache that will be in your server.
-- Custom Cache: the library available an interface `CustomCache` with this interface you can implement your owner cache manager.
+- **Redis Cache:** Use Redis to manage your cache. Ideal for environments that require scalability.
+- **Cache in Memory:** it does not have support to scale this is only a simple cache that will be in your server.
+- **Custom Cache:** the library available an interface `CustomCache` with this interface you can implement your owner cache manager.
+
+### Note
+- If your storage needs are in a different location, then you need to implement a class with the Custom interface and pass the instance of this class to the `cache` attribute. When doing this, the `strategyCache` property must be set to `CUSTOM`.
 
 
 ## TypeScript Support
 
 This library provides interfaces that can be used with TypeScript.
 
-|    Interface     |                                       Description                                       |
-| :--------------: | :-------------------------------------------------------------------------------------: |
-| CustomCache:     | the interface provides a model for the implementation custom cache.                     |
-| RateLimitCache:  |           interface provides a model for the response of the CustomCache.               |
-| Settings:        |       interface provides a model for the construction parameters of the library.        |
+|    Interface    |                                                                   Description                                                                   |
+|:---------------:|:-----------------------------------------------------------------------------------------------------------------------------------------------:|
+|     Redis:      | You do not need to install the Redis library in your project. Simply obtain the Redis object through the import from express-rate-limiter-core. |
+|  CustomCache:   |                                       the interface provides a model for the implementation custom cache.                                       |
+| RateLimitCache: |                                         interface provides a model for the response of the CustomCache.                                         |
+|    Settings:    |                                   interface provides a model for the construction parameters of the library.                                    |
 
 ## Exemples
 
@@ -51,19 +58,66 @@ This library provides interfaces that can be used with TypeScript.
 ```javascript
 import {
   RateLimitExpress,
+  Redis,
+
 } from "express-rate-limiter-core";
 ```
 
 ### Request per Seconds or Minutes
 
 ```javascript
+
+// Exemple RateLimitExpress with cache in Memory
 const app = express();
 
 const rateLimit = RateLimitExpress({
+  // This field is optional; when not defined, it defaults to IN_MEMORY.
+  strategyCache: 'IN_MEMORY',
+
   policy: {
     type: "REQUEST_PER_SECONDS", // REQUEST_PER_SECONDS, REQUEST_PER_MINUTES
 
-    // This property can two variations. When the type policy is REQUEST_PER_SECONDS the value represented here is seconds and when the type policy is REQUEST_PER_MINUTES the value is minutes.
+    periodWindow: 10,
+
+    maxRequests: 10,
+  },
+  },
+});
+
+// Exemple RateLimitExpress with cache in Redis
+const redisClient = Redis.createClient({
+    url: 'redis://localhost:6379'
+});
+
+const rateLimit = RateLimitExpress({
+  // This field is optional and support IN_MEMORY, REDIS and CUSTOM
+  strategyCache: 'REDIS',
+  
+  redis: redisClient,
+
+  policy: {
+    type: "REQUEST_PER_SECONDS", // REQUEST_PER_SECONDS, REQUEST_PER_MINUTES
+
+    periodWindow: 10,
+
+    maxRequests: 10,
+  },
+});
+
+// The implementation can be done in any storage you need. The only requirement is to respect the interface contracts; if you wish, you can draw inspiration from already implemented repositories.
+
+class CustomCacheExemple implements CustomCache {}
+
+// Exemple RateLimitExpress with custom cache
+const rateLimit = RateLimitExpress({
+  // This field is optional and support IN_MEMORY, REDIS and CUSTOM
+  strategyCache: 'CUSTOM',
+
+  cache: new CustomCacheExemple(),
+
+  policy: {
+    type: "REQUEST_PER_SECONDS", // REQUEST_PER_SECONDS, REQUEST_PER_MINUTES
+
     periodWindow: 10,
 
     maxRequests: 10,
@@ -74,7 +128,10 @@ const rateLimit = RateLimitExpress({
 ### Request per Period
 
 ```javascript
+
+// Exemple RateLimitExpress with cache in Memory
 const rateLimit = RateLimitExpress({
+
   policy: {
     type: "REQUEST_PER_PERIOD",
 
@@ -93,6 +150,8 @@ const rateLimit = RateLimitExpress({
 ### Block Request Rule
 
 ```javascript
+// exemple cache in memory
+
 import express from "express";
 import { RateLimitExpress } from "express-rate-limiter-core";
 
@@ -139,18 +198,21 @@ app.use(rateLimit.apply);
 
 ## Constructor Parameters
 
-|     Parameter      | Require |                                                                   Description                                                                   |
-| :----------------: | :-----: | :---------------------------------------------------------------------------------------------------------------------------------------------: |
-|      `cache`       |   No   | Accepts a custom cache instance is used to store rate-limiting information. When the property doesn't define the cache used is in memory. |
-|      `policy`      |   Yes   |                                                         A object with policy to service                                                         |
-| `blockRequestRule` |   No    |     function optional to implement the rule of locking in your service. The function receives the property 'request' of the object express.     |
+|     Parameter      | Required | Description                                                                                                                                                                                                     |
+|--------------------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+  `redis`           | No       | This property should be the instance of your Redis. If you wish, you can import the `Redis` library with `import { Redis } from "express-rate-limiter-core";`.                                                   |
+|  `cache`           | No       | Accepts a custom cache instance to store rate-limiting information. This property should be used in conjunction with `strategyCache` set to `CUSTOM`. |
+|  `policy`          | Yes      | A object with policy to service.                                                                                                                                                                                |
+|  `strategyCache`   | No       | This property is used as a cache strategy, allowing you to set the values `IN_MEMORY`, `REDIS`, or `CUSTOM`.                                                                                                     |
+| `blockRequestRule` | No       | Function optional to implement the rule of locking in your service. The function receives the property 'request' of the object express.                                                                          |
+
 
 ### Policy to Request per Seconds
 
 Object Specification `policy`:
 
 |       Parameter       |         Type          | Require | Description                                                                                                                                                                      |
-| :-------------------: | :-------------------: | :-----: | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|:---------------------:|:---------------------:|:-------:|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 |     `policy.type`     | `REQUEST_PER_SECONDS` |  true   | type policy                                                                                                                                                                      |
 | `policy.periodWindow` |        number         |  true   | period window in seconds is utilized to calculate the time wait. Exemple: if defined `maxRequest: 100` and `periodWindow:60` the user needs to wait 60 seconds after 100 requets |
 | `policy.maxRequests`  |        number         |  true   | is the number request that the client 'ip' to can receive                                                                                                                        |
@@ -160,7 +222,7 @@ Object Specification `policy`:
 Object Specification `policy`:
 
 |       Parameter       |         Type          | Require | Description                                                                                                                                                                      |
-| :-------------------: | :-------------------: | :-----: | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|:---------------------:|:---------------------:|:-------:|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 |     `policy.type`     | `REQUEST_PER_MINUTES` |  true   | type policy                                                                                                                                                                      |
 | `policy.periodWindow` |        number         |  true   | period window in minutes is utilized to calculate the time wait. Exemple: if defined `maxRequest: 100` and `periodWindow:60` the user needs to wait 60 minutos after 100 requets |
 | `policy.maxRequests`  |        number         |  true   | is the number request that the client 'ip' to can receive                                                                                                                        |
@@ -170,7 +232,7 @@ Object Specification `policy`:
 Object Specification `policy`:
 
 |         Parameter          |         Type         | Require | Description                                               |
-| :------------------------: | :------------------: | :-----: | --------------------------------------------------------- |
+|:--------------------------:|:--------------------:|:-------:|-----------------------------------------------------------|
 |       `policy.type`        | `REQUEST_PER_PERIOD` |  true   | type policy                                               |
 |    `policy.maxRequests`    |        number        |  true   | is the number request that the client 'ip' to can receive |
 | `policy.periodWindowStart` |         Date         |  true   | date representing when rate-limit will be start           |
@@ -180,17 +242,17 @@ Object Specification `policy`:
 ## Response
 
 | Status code |                            message                             |                                                                                                               description                                                                                                               |
-| :---------: | :------------------------------------------------------------: | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: |
+|:-----------:|:--------------------------------------------------------------:|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------:|
 |     429     | Too many requests. You've exceeded the rate-limit for requests |                                                                          This message is returned to all types of policies when the request limit is exceeded.                                                                          |
 |     403     |                     Unauthorized Request!                      |                                                     This message is returned only when the property `blockRequestRule` is passed in the instance of the library and returns `True`.                                                     |
-|     500     |                    Other errors                  | This message is returned ever that a property doesn't is passed correctly in the instance of the library. Possible scenaries: `MISSING_PROPERTY`,`PROPERTY_IS_NOT_INSTANCE_DATE`,`PROPERTY_IS_NOT_NUMBER` and `PROPERTY_IS_NOT_STRING`, |
+|     500     |                          Other errors                          | This message is returned ever that a property doesn't is passed correctly in the instance of the library. Possible scenaries: `MISSING_PROPERTY`,`PROPERTY_IS_NOT_INSTANCE_DATE`,`PROPERTY_IS_NOT_NUMBER` and `PROPERTY_IS_NOT_STRING`, |
 
 ## Headers
 
 |         Header          | Always Returned |                                                                                                                                                          Description                                                                                                                                                           |
-| :---------------------: | :-------------: | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: |
+|:-----------------------:|:---------------:|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------:|
 |   `X-RateLimit-Limit`   |       Yes       |                                                                                                                                               used to identify max request limit                                                                                                                                               |
-| `X-RateLimit-Remaining` |       No       |                                                                                                                                   used to identify the quantity remaining max request limit. This header is returned only if the quantity is less than max limit.                                                                                                                                   |
+| `X-RateLimit-Remaining` |       No        |                                                                                                used to identify the quantity remaining max request limit. This header is returned only if the quantity is less than max limit.                                                                                                 |
 |   `X-RateLimit-Reset`   |       No        | This header is used to identify when the limiter is reset and only is returned when the request limit hit. The value é represented in as ISO string. The header only is returned when the rate-limit was hit. When the policy is `REQUEST_PER_PERIOD` the header returns the value of property `periodWindowEnd` as ISO string |
 |      `Retry-After`      |       No        |                           used to tells the client how long in seconds to wait before making another request. The header only is returned when the rate-limit was hit. When the policy is `REQUEST_PER_PERIOD` the header returns difference between timestamp now and `periodWindowEnd` in seconds.                           |
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "redis": "^4.6.13"
   },
   "devDependencies": {
     "@types/express": "^4.17.17",
@@ -49,6 +50,7 @@
     "eslint-plugin-n": "^15.6.1",
     "eslint-plugin-promise": "^6.1.1",
     "jest": "^29.4.3",
+    "prettier": "^3.2.5",
     "ts-jest": "^29.0.5",
     "typescript": "^4.9.5"
   },

--- a/src/core/policies/policies.factory.ts
+++ b/src/core/policies/policies.factory.ts
@@ -24,7 +24,7 @@ export class PoliciesFactory {
     this.responseRateLimitCache = responseRateLimitCache;
     this.repositoryCache = repositoryCache;
   }
-  s;
+
   /**
    * Create an instance of super type RateLimitPolicy
    * @returns {RateLimitPolicy} instance

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,6 @@
+import * as Redis from "redis";
 import { MemoryCacheRepository } from "./shared/repositories/memory-cache.repository";
-import {
-  ICache as CustomCache,
-  IRateLimitCache as RateLimitCache,
-} from "./shared/interfaces/cache";
+import { ICache as CustomCache, IRateLimitCache as RateLimitCache } from "./shared/interfaces/cache";
 
 import { ISettings as Settings } from "./shared/interfaces/settings";
 import { middleware } from "./shared/middleware";
@@ -20,4 +18,4 @@ export const MemoryCache = MemoryCacheRepository;
 /**
  * Interfaces Types
  */
-export { CustomCache, RateLimitCache, Settings };
+export { CustomCache, RateLimitCache, Settings, Redis };

--- a/src/shared/get-strategy-cache.spec.ts
+++ b/src/shared/get-strategy-cache.spec.ts
@@ -1,0 +1,86 @@
+import { ISettings } from "./interfaces/settings";
+import { MemoryCacheRepository } from "./repositories/memory-cache.repository";
+import { RedisCacheRepository } from "./repositories/redis-cache.repository";
+import { getStrategyCache } from "./get-strategy-cache";
+import { RedisCache } from "./interfaces/cache";
+
+jest.mock("./repositories/memory-cache.repository");
+jest.mock("./repositories/redis-cache.repository");
+
+const settingsBase: ISettings = {
+	policy: {
+		type: "REQUEST_PER_SECONDS",
+		periodWindow: 10,
+		maxRequests: 10,
+	},
+};
+
+describe("getStrategyCache unit test", () => {
+	beforeEach(() => {
+		(RedisCacheRepository.getInstance as jest.Mock).mockReturnValue(
+			new RedisCacheRepository({} as unknown as RedisCache)
+		);
+		(MemoryCacheRepository.getInstance as jest.Mock).mockReturnValue(
+			new MemoryCacheRepository()
+		);
+	});
+
+	it("should return an instance of MemoryCacheRepository when no strategy is specified", () => {
+		const settings = settingsBase;
+		expect(getStrategyCache(settings)).toBeInstanceOf(MemoryCacheRepository);
+	});
+
+	it("should return an instance of MemoryCacheRepository when strategy is IN_MEMORY", () => {
+		const settings: ISettings = { ...settingsBase, strategyCache: "IN_MEMORY" };
+		expect(getStrategyCache(settings)).toBeInstanceOf(MemoryCacheRepository);
+	});
+
+	it("should throw an error when strategy is CUSTOM without a cache implementation", () => {
+		const settings: ISettings = {
+			...settingsBase,
+			strategyCache: "CUSTOM",
+			cache: undefined,
+		} as unknown as ISettings;
+		expect(() => getStrategyCache(settings)).toThrow(
+			"When the property 'strategyCache' is 'CUSTOM', the property 'cache' is required."
+		);
+	});
+
+	it("should return a custom cache implementation when strategy is CUSTOM with a cache", () => {
+		const customCache = { set: jest.fn(), get: jest.fn() };
+		const settings: ISettings = {
+			...settingsBase,
+			strategyCache: "CUSTOM",
+			cache: customCache,
+		} as unknown as ISettings;
+
+		expect(getStrategyCache(settings)).toEqual(customCache);
+	});
+
+	it("should throw an error when strategy is REDIS without Redis configuration", () => {
+		const settings: ISettings = {
+			...settingsBase,
+			strategyCache: "REDIS",
+		} as unknown as ISettings;
+
+		expect(() => getStrategyCache(settings)).toThrow(
+			"When the property 'strategyCache' is 'REDIS', the property 'redis' is required."
+		);
+	});
+
+	it("should return an instance of RedisCacheRepository when strategy is REDIS with Redis configuration", () => {
+		const redisClient = {} as RedisCache;
+
+		const settings: ISettings = {
+			strategyCache: "REDIS",
+			redis: redisClient,
+			policy: {
+				type: "REQUEST_PER_SECONDS",
+				periodWindow: 10,
+				maxRequests: 10,
+			},
+		};
+
+		expect(getStrategyCache(settings)).toBeInstanceOf(RedisCacheRepository);
+	});
+});

--- a/src/shared/get-strategy-cache.ts
+++ b/src/shared/get-strategy-cache.ts
@@ -1,0 +1,31 @@
+import { ICache } from "./interfaces/cache";
+import { ISettings } from "./interfaces/settings";
+import { MemoryCacheRepository } from "./repositories/memory-cache.repository";
+import { RedisCacheRepository } from "./repositories/redis-cache.repository";
+
+export const getStrategyCache = (settings: ISettings): ICache => {
+  // Default to IN_MEMORY if no strategy is specified or if IN_MEMORY is explicitly specified
+  if (!settings.strategyCache || settings.strategyCache === "IN_MEMORY") {
+    return MemoryCacheRepository.getInstance();
+  }
+
+  // Ensure that a custom cache is provided if the strategy is CUSTOM
+  if (settings.strategyCache === "CUSTOM") {
+    if (!settings.cache) {
+      throw new Error("When the property 'strategyCache' is 'CUSTOM', the property 'cache' is required.");
+    }
+    return settings.cache;
+  }
+
+  // Ensure that Redis configuration is provided if the strategy is REDIS
+  if (settings.strategyCache === "REDIS") {
+    if (!settings.redis) {
+      throw new Error("When the property 'strategyCache' is 'REDIS', the property 'redis' is required.");
+    }
+
+    return RedisCacheRepository.getInstance(settings.redis);
+  }
+
+  // Return MemoryCacheRepository by default if no valid strategy is matched (fallback safety)
+  return MemoryCacheRepository.getInstance();
+};

--- a/src/shared/interfaces/cache.ts
+++ b/src/shared/interfaces/cache.ts
@@ -1,3 +1,5 @@
+import { RedisClientType, RedisFunctions, RedisModules, RedisScripts } from "redis";
+
 /* eslint-disable no-unused-vars */
 export interface IRateLimitCache {
   /**
@@ -15,6 +17,10 @@ export interface IRateLimitCache {
    */
   created_at: number;
 }
+
+export type RedisCache = RedisClientType<RedisModules, RedisFunctions, RedisScripts>;
+
+export type CacheStrategy = "REDIS" | "IN_MEMORY" | "CUSTOM";
 
 export interface ICache {
   /**

--- a/src/shared/interfaces/settings.ts
+++ b/src/shared/interfaces/settings.ts
@@ -1,17 +1,17 @@
 /* eslint-disable no-unused-vars */
 import { RequestExpress } from "../../core/interfaces/express";
 import { PolicieRateLimit } from "../../core/interfaces/policies";
-import { ICache } from "./cache";
+import { CacheStrategy, ICache, RedisCache } from "./cache";
 
 export type BlockRequestRule = (req: RequestExpress) => boolean;
 
-export interface ISettings {
+interface ISettingsBase {
+  strategyCache?: CacheStrategy;
+
   /**
-   * This atributte  is opcional and needs to receive an classe to type ICache.
-   * You can implement a custom Cache if you want as long as the interface is respected
-   * @default MemoryCache
+   * The object with settings to policy rate-limit.
    */
-  cache?: ICache;
+  policy: PolicieRateLimit;
 
   /**
    * This function can to be implemented to forbidden a request.
@@ -19,9 +19,42 @@ export interface ISettings {
    * @returns {boolean}
    */
   blockRequestRule?: BlockRequestRule;
+}
+
+interface ISettingsMemoryCache extends ISettingsBase {
+  /**
+   * Specifies the type of cache to use.
+   * @default IN_MEMORY
+   */
+  strategyCache?: "IN_MEMORY";
+}
+
+interface ISettingsRedisCache extends ISettingsBase {
+  redis: RedisCache;
 
   /**
-   * The object with settings to policy rate-limit.
+   * Specifies the type of cache to use.
+   * @default IN_MEMORY
    */
-  policy: PolicieRateLimit;
+  strategyCache?: "REDIS";
 }
+
+interface ISettingsCustomCache extends ISettingsBase {
+  /**
+   * Specifies the type of cache to use.
+   * @default IN_MEMORY
+   */
+  strategyCache?: "CUSTOM";
+
+  /**
+   * This atributte  is opcional and needs to receive an classe to type ICache.
+   * You can implement a custom Cache if you want as long as the interface is respected
+   * @default MemoryCache
+   */
+  cache: ICache;
+}
+
+export type ISettings =
+  | ISettingsMemoryCache
+  | ISettingsRedisCache
+  | ISettingsCustomCache;

--- a/src/shared/middleware.spec.ts
+++ b/src/shared/middleware.spec.ts
@@ -2,18 +2,15 @@ import { middleware } from "./middleware";
 
 import { ArgumentsPolicyDTO } from "../app/dtos/arguments-policy.dto";
 import { RequestExpressDTO } from "../app/dtos/request-express.dto";
-import { MemoryCacheRepository } from "../shared/repositories/memory-cache.repository";
-import { ICache } from "../shared/interfaces/cache";
-import {
-  RequestExpress,
-  ResponseExpress,
-  NextFunctionExpress,
-} from "../core/interfaces/express";
+import { ICache, RedisCache } from "../shared/interfaces/cache";
+import { RequestExpress, ResponseExpress, NextFunctionExpress } from "../core/interfaces/express";
+import { getStrategyCache } from "./get-strategy-cache";
 import { Application } from "../app/application";
 
 jest.mock("../app/application");
 jest.mock("../app/dtos/arguments-policy.dto");
 jest.mock("../app/dtos/request-express.dto");
+jest.mock("./get-strategy-cache.ts");
 
 const req = {} as RequestExpress;
 const res = {
@@ -24,18 +21,19 @@ const nextFn = jest.fn<NextFunctionExpress, []>();
 
 const requestExpressDtoFn = jest.fn();
 const argumentsPolicyftoFn = jest.fn();
-const constructorApplication = jest.fn();
+const constructorApplicationFn = jest.fn();
+const strategyCacheFn = jest.fn();
 
 describe("middleware unit test", () => {
   beforeEach(() => {
-    (Application as jest.Mock).mockImplementation(constructorApplication);
+    (Application as jest.Mock).mockImplementation(constructorApplicationFn);
     (RequestExpressDTO as jest.Mock).mockImplementation(requestExpressDtoFn);
     (ArgumentsPolicyDTO as jest.Mock).mockImplementation(argumentsPolicyftoFn);
+    (getStrategyCache as jest.Mock).mockImplementation(strategyCacheFn);
   });
 
-  test("it's should call apply function correctly with memory cache", () => {
+  test("it should call apply function correctly when strategy cache is in memory (without strategyCache)", () => {
     const spyApply = jest.spyOn(Application.prototype, "execute");
-    const spyGetInstance = jest.spyOn(MemoryCacheRepository, "getInstance");
 
     const mw = middleware({
       policy: {
@@ -47,20 +45,43 @@ describe("middleware unit test", () => {
 
     mw.apply(req, res, nextFn);
 
-    expect(constructorApplication).toBeCalled();
-    expect(argumentsPolicyftoFn).toBeCalled();
-    expect(requestExpressDtoFn).toBeCalled();
-    expect(spyGetInstance).toBeCalled();
-    expect(spyApply).toBeCalled();
+    expect(strategyCacheFn).toHaveBeenCalled();
+    expect(constructorApplicationFn).toHaveBeenCalled();
+    expect(argumentsPolicyftoFn).toHaveBeenCalled();
+    expect(requestExpressDtoFn).toHaveBeenCalled();
+    expect(spyApply).toHaveBeenCalled();
 
     spyApply.mockRestore();
-    spyGetInstance.mockRestore();
   });
 
-  test("it's should call apply function correctly when receive custom cache", () => {
+  test("it should call apply function correctly when strategy cache is in memory (with strategyCache)", () => {
     const spyApply = jest.spyOn(Application.prototype, "execute");
 
     const mw = middleware({
+      strategyCache: "IN_MEMORY",
+      policy: {
+        type: "REQUEST_PER_SECONDS",
+        maxRequests: 10,
+        periodWindow: 10,
+      },
+    });
+
+    mw.apply(req, res, nextFn);
+
+    expect(strategyCacheFn).toHaveBeenCalled();
+    expect(constructorApplicationFn).toHaveBeenCalled();
+    expect(argumentsPolicyftoFn).toHaveBeenCalled();
+    expect(requestExpressDtoFn).toHaveBeenCalled();
+    expect(spyApply).toHaveBeenCalled();
+
+    spyApply.mockRestore();
+  });
+
+  test("it should call apply function correctly when strategy cache is custom", () => {
+    const spyApply = jest.spyOn(Application.prototype, "execute");
+
+    const mw = middleware({
+      strategyCache: "CUSTOM",
       cache: {} as ICache,
       policy: {
         type: "REQUEST_PER_SECONDS",
@@ -71,19 +92,43 @@ describe("middleware unit test", () => {
 
     mw.apply(req, res, nextFn);
 
-    expect(constructorApplication).toBeCalled();
-    expect(argumentsPolicyftoFn).toBeCalled();
-    expect(requestExpressDtoFn).toBeCalled();
-    expect(spyApply).toBeCalled();
+    expect(strategyCacheFn).toHaveBeenCalled();
+    expect(constructorApplicationFn).toHaveBeenCalled();
+    expect(argumentsPolicyftoFn).toHaveBeenCalled();
+    expect(requestExpressDtoFn).toHaveBeenCalled();
+    expect(spyApply).toHaveBeenCalled();
 
     spyApply.mockRestore();
   });
 
-  test("it's should call apply function correctly when receive blockRequestRule", () => {
+  test("it should call apply function correctly when strategy cache is redis", () => {
     const spyApply = jest.spyOn(Application.prototype, "execute");
 
     const mw = middleware({
-      cache: {} as ICache,
+      strategyCache: "REDIS",
+      redis: {} as RedisCache,
+      policy: {
+        type: "REQUEST_PER_SECONDS",
+        maxRequests: 10,
+        periodWindow: 10,
+      },
+    });
+
+    mw.apply(req, res, nextFn);
+
+    expect(strategyCacheFn).toHaveBeenCalled();
+    expect(constructorApplicationFn).toHaveBeenCalled();
+    expect(argumentsPolicyftoFn).toHaveBeenCalled();
+    expect(requestExpressDtoFn).toHaveBeenCalled();
+    expect(spyApply).toHaveBeenCalled();
+
+    spyApply.mockRestore();
+  });
+
+  test("it should call apply function correctly when receive blockRequestRule", () => {
+    const spyApply = jest.spyOn(Application.prototype, "execute");
+
+    const mw = middleware({
       policy: {
         type: "REQUEST_PER_SECONDS",
         maxRequests: 10,
@@ -96,20 +141,19 @@ describe("middleware unit test", () => {
 
     mw.apply(req, res, nextFn);
 
-    expect(constructorApplication).toBeCalled();
-    expect(argumentsPolicyftoFn).toBeCalled();
-    expect(requestExpressDtoFn).toBeCalled();
-    expect(spyApply).toBeCalled();
+    expect(strategyCacheFn).toHaveBeenCalled();
+    expect(constructorApplicationFn).toHaveBeenCalled();
+    expect(argumentsPolicyftoFn).toHaveBeenCalled();
+    expect(requestExpressDtoFn).toHaveBeenCalled();
+    expect(spyApply).toHaveBeenCalled();
 
     spyApply.mockRestore();
   });
 
-  test("it's should catch and handle errors", () => {
-    const executeSpy = jest
-      .spyOn(Application.prototype, "execute")
-      .mockImplementation(() => {
-        throw new Error("Simulate Error!");
-      });
+  test("it should catch and handle errors", () => {
+    const executeSpy = jest.spyOn(Application.prototype, "execute").mockImplementation(() => {
+      throw new Error("Simulate Error!");
+    });
 
     middleware({
       policy: {

--- a/src/shared/middleware.ts
+++ b/src/shared/middleware.ts
@@ -3,32 +3,20 @@ import { HTTP_STATUS_INTERNAL_SERVER_ERROR } from "../core/constants";
 
 import { IMiddleware } from "../core/interfaces/middleware";
 
-import {
-  RequestExpress,
-  ResponseExpress,
-  NextFunctionExpress,
-} from "../core/interfaces/express";
-import { MemoryCacheRepository } from "./repositories/memory-cache.repository";
+import { RequestExpress, ResponseExpress, NextFunctionExpress } from "../core/interfaces/express";
 import { ArgumentsPolicyDTO } from "../app/dtos/arguments-policy.dto";
 import { RequestExpressDTO } from "../app/dtos/request-express.dto";
 import { ISettings } from "./interfaces/settings";
+import { getStrategyCache } from "./get-strategy-cache";
 
 export const middleware = (settings: ISettings): IMiddleware => {
   return {
-    apply: (
-      req: RequestExpress,
-      res: ResponseExpress,
-      next: NextFunctionExpress
-    ) => {
+    apply: (req: RequestExpress, res: ResponseExpress, next: NextFunctionExpress) => {
       try {
         const requestExpressDto = new RequestExpressDTO(req, res, next);
         const argumentsPolicyDto = new ArgumentsPolicyDTO(settings.policy);
         const blockRequestRule = settings?.blockRequestRule;
-
-        // if the cache was defined in a library instance use that was defined otherwise use repository in memory
-        const cache = settings?.cache
-          ? settings?.cache
-          : MemoryCacheRepository.getInstance();
+        const cache = getStrategyCache(settings);
 
         const app = new Application({
           blockRequestRule,

--- a/src/shared/repositories/redis-cache.repository.ts
+++ b/src/shared/repositories/redis-cache.repository.ts
@@ -1,0 +1,60 @@
+import {
+  RedisClientType,
+  RedisFunctions,
+  RedisModules,
+  RedisScripts,
+} from "redis";
+import { ICache, IRateLimitCache } from "../interfaces/cache";
+
+export class RedisCacheRepository implements ICache {
+  private static instance: RedisCacheRepository;
+
+  private client;
+
+  constructor(
+    clientRedis: RedisClientType<RedisModules, RedisFunctions, RedisScripts>
+  ) {
+    this.client = clientRedis;
+  }
+
+  static getInstance(
+    clientRedis: RedisClientType<RedisModules, RedisFunctions, RedisScripts>
+  ): RedisCacheRepository {
+    if (!RedisCacheRepository.instance) {
+      RedisCacheRepository.instance = new RedisCacheRepository(clientRedis);
+    }
+    return RedisCacheRepository.instance;
+  }
+
+  async saveHit(key: string, newHit: number): Promise<IRateLimitCache> {
+    const data: IRateLimitCache = {
+      hits: newHit,
+      last_time_request: Date.now(),
+      created_at: Date.now(),
+    };
+    await this.client.set(key, JSON.stringify(data));
+
+    return data;
+  }
+
+  async updateHit(key: string, newHit: number): Promise<IRateLimitCache> {
+    const data: IRateLimitCache = {
+      hits: newHit,
+      last_time_request: Date.now(),
+      created_at: Date.now(),
+    };
+
+    await this.client.set(key, JSON.stringify(data));
+    return data;
+  }
+
+  async deleteHit(key: string): Promise<boolean> {
+    const response = await this.client.del(key);
+    return response > 0;
+  }
+
+  async getByKey(key: string): Promise<IRateLimitCache> {
+    const response = await this.client.get(key);
+    return JSON.parse(response || "{}") as IRateLimitCache;
+  }
+}


### PR DESCRIPTION
### What has been implemented?

Support for Redis has been added, allowing rate limit management directly via Redis. New properties have been added: `strategyCache` and `redis`.

### Important

- For those using a custom cache where it is necessary to inform the `cache` field containing the instance of the custom cache, in addition to this field, you will need to add `strategyCache: "CUSTOM"`. If you were using in-memory cache, don't worry, nothing has changed.

### Example of Use

- For more details, please consult the [README.md](https://github.com/JeffersonGibin/express-rate-limiter-core/tree/feature/redis-cache-strategy-implementation?tab=readme-ov-file#request-per-seconds-or-minutes).


### Redis

```typescript

import {  RateLimitExpress,  Redis } from "express-rate-limiter-core"; 

const redisClient = Redis.createClient({
    url: 'redis://localhost:6379'
});

redisClient.connect();

const rateLimit = RateLimitExpress({
  // This field is optional and support IN_MEMORY, REDIS and CUSTOM
  strategyCache: 'REDIS',
  
  redis: redisClient,

  policy: {
    type: "REQUEST_PER_SECONDS", // REQUEST_PER_SECONDS, REQUEST_PER_MINUTES

    periodWindow: 10,

    maxRequests: 10,
  },
});

```
### Custom Cache

```typescript

import {  RateLimitExpress } from "express-rate-limiter-core"; 

class CustomCacheExemple implements CustomCache {}

// Exemple RateLimitExpress with custom cache
const rateLimit = RateLimitExpress({
  // This field is optional and support IN_MEMORY, REDIS and CUSTOM
  strategyCache: 'CUSTOM',

  cache: new CustomCacheExemple(),

  policy: {
    type: "REQUEST_PER_SECONDS", // REQUEST_PER_SECONDS, REQUEST_PER_MINUTES

    periodWindow: 10,

    maxRequests: 10,
  },
});

```